### PR TITLE
Changes to v1-periphery to work with v1-core changes from halborn audit

### DIFF
--- a/contracts/PositionManager.sol
+++ b/contracts/PositionManager.sol
@@ -100,7 +100,7 @@ contract PositionManager is IPositionManager, ISendTokensCallback, Transfers, Ga
         uint256 liquidity;
         uint256 lpTokens;
         (, ,  tokensHeld, initLiquidity, liquidity, lpTokens, ) = IGammaPool(gammaPool).loan(tokenId);
-        emit LoanUpdate(tokenId, gammaPool, owner, tokensHeld, liquidity, lpTokens, initLiquidity, IGammaPool(gammaPool).getCFMMPrice());
+        emit LoanUpdate(tokenId, gammaPool, owner, tokensHeld, liquidity, lpTokens, initLiquidity, IGammaPool(gammaPool).getLatestCFMMReserves());
     }
 
     function checkMinReserves(uint256[] memory amounts, uint256[] memory amountsMin) internal virtual pure {

--- a/contracts/interfaces/IPositionManager.sol
+++ b/contracts/interfaces/IPositionManager.sol
@@ -19,7 +19,7 @@ interface IPositionManager  is ITransfers {
       uint256 lpTokenBorrowedPlusInterest, uint256 lpInvariant, uint256 lpBorrowedInvariant);
     event LoanCreated(address indexed caller, uint256 tokenId);
     event LoanUpdated(uint256 indexed tokenId, uint128[] tokensHeld, uint256 liquidity, uint256 lpTokens, uint256 rateIndex);
-    event LoanUpdate(uint256 indexed tokenId, address indexed poolId, address indexed owner, uint128[] tokensHeld, uint256 liquidity, uint256 lpTokens, uint256 initLiquidity, uint256 lastPx);
+    event LoanUpdate(uint256 indexed tokenId, address indexed poolId, address indexed owner, uint128[] tokensHeld, uint256 liquidity, uint256 lpTokens, uint256 initLiquidity, uint256[] cfmmReserves);
 
     struct DepositWithdrawParams {
         uint16 protocolId;

--- a/contracts/interfaces/IPositionManager.sol
+++ b/contracts/interfaces/IPositionManager.sol
@@ -50,7 +50,6 @@ interface IPositionManager  is ITransfers {
     struct BorrowLiquidityParams {
         uint16 protocolId;
         address cfmm;
-        address to;
         uint256 tokenId;
         uint256 lpTokens;
         uint256 deadline;
@@ -60,7 +59,6 @@ interface IPositionManager  is ITransfers {
     struct RepayLiquidityParams {
         uint16 protocolId;
         address cfmm;
-        address to;
         uint256 tokenId;
         uint256 liquidity;
         uint256 deadline;
@@ -79,7 +77,6 @@ interface IPositionManager  is ITransfers {
     struct RebalanceCollateralParams {
         uint16 protocolId;
         address cfmm;
-        address to;
         uint256 tokenId;
         uint256 deadline;
         int256[] deltas;
@@ -141,7 +138,7 @@ interface IPositionManager  is ITransfers {
     function increaseCollateral(AddRemoveCollateralParams calldata params) external returns(uint128[] memory tokensHeld);
     function decreaseCollateral(AddRemoveCollateralParams calldata params) external returns(uint128[] memory tokensHeld);
     function rebalanceCollateral(RebalanceCollateralParams calldata params) external returns(uint128[] memory tokensHeld);
-    function createLoanBorrowAndRebalance(CreateLoanBorrowAndRebalanceParams calldata params) external virtual returns(uint256 tokenId, uint128[] memory tokensHeld, uint256[] memory amounts);
-    function borrowAndRebalance(BorrowAndRebalanceParams calldata params) external virtual returns(uint128[] memory tokensHeld, uint256[] memory amounts);
-    function rebalanceRepayAndWithdraw(RebalanceRepayAndWithdrawParams calldata params) external virtual returns(uint128[] memory tokensHeld, uint256 liquidityPaid, uint256[] memory amounts);
+    function createLoanBorrowAndRebalance(CreateLoanBorrowAndRebalanceParams calldata params) external returns(uint256 tokenId, uint128[] memory tokensHeld, uint256[] memory amounts);
+    function borrowAndRebalance(BorrowAndRebalanceParams calldata params) external returns(uint128[] memory tokensHeld, uint256[] memory amounts);
+    function rebalanceRepayAndWithdraw(RebalanceRepayAndWithdrawParams calldata params) external returns(uint128[] memory tokensHeld, uint256 liquidityPaid, uint256[] memory amounts);
 }

--- a/contracts/interfaces/IPositionManager.sol
+++ b/contracts/interfaces/IPositionManager.sol
@@ -15,11 +15,16 @@ interface IPositionManager  is ITransfers {
     event IncreaseCollateral(address indexed pool, uint256 tokenId, uint256 tokensHeldLen);
     event DecreaseCollateral(address indexed pool, uint256 tokenId, uint256 tokensHeldLen);
     event RebalanceCollateral(address indexed pool, uint256 tokenId, uint256 tokensHeldLen);
+    event LoanUpdate(uint256 indexed tokenId, address indexed poolId, address indexed owner, uint128[] tokensHeld,
+        uint256 liquidity, uint256 lpTokens, uint256 initLiquidity, uint256[] cfmmReserves);
+
     event PoolUpdated(uint256 lpTokenBalance, uint256 lpTokenBorrowed, uint256 lastBlockNumber, uint256 accFeeIndex,
-      uint256 lpTokenBorrowedPlusInterest, uint256 lpInvariant, uint256 lpBorrowedInvariant);
+        uint256 lpTokenBorrowedPlusInterest, uint256 lpInvariant, uint256 borrowedInvariant);
     event LoanCreated(address indexed caller, uint256 tokenId);
     event LoanUpdated(uint256 indexed tokenId, uint128[] tokensHeld, uint256 liquidity, uint256 lpTokens, uint256 rateIndex);
-    event LoanUpdate(uint256 indexed tokenId, address indexed poolId, address indexed owner, uint128[] tokensHeld, uint256 liquidity, uint256 lpTokens, uint256 initLiquidity, uint256[] cfmmReserves);
+
+    event Deposit(address indexed caller, address indexed to, uint256 assets, uint256 shares);
+    event Withdraw(address indexed caller, address indexed to, address indexed from, uint256 assets, uint256 shares);
 
     struct DepositWithdrawParams {
         uint16 protocolId;

--- a/contracts/test/TestGammaPool.sol
+++ b/contracts/test/TestGammaPool.sol
@@ -78,20 +78,20 @@ contract TestGammaPool is IGammaPool, ERC20 {
         data.CFMM_RESERVES = new uint128[](2);
     }
 
-    function testSendTokensCallback(address posAddr, address[] calldata tokens, uint256[] calldata amounts, address payee, bytes calldata data) external virtual {
-        ISendTokensCallback(posAddr).sendTokensCallback(tokens, amounts, payee, data);
+    function testSendTokensCallback(address posAddr, address[] calldata _tokens, uint256[] calldata amounts, address payee, bytes calldata data) external virtual {
+        ISendTokensCallback(posAddr).sendTokensCallback(_tokens, amounts, payee, data);
     }
 
     //Short Gamma
-    function depositNoPull(address to) external virtual override returns(uint256 shares) {
+    function depositNoPull(address) external virtual override returns(uint256 shares) {
         shares = 15;
     }
 
-    function withdrawNoPull(address to) external virtual override returns(uint256 assets) {
+    function withdrawNoPull(address) external virtual override returns(uint256 assets) {
         assets = 16;
     }
 
-    function withdrawReserves(address to) external virtual override returns (uint256[] memory reserves, uint256 assets) {
+    function withdrawReserves(address) external virtual override returns (uint256[] memory reserves, uint256 assets) {
         reserves = new uint256[](3);
         reserves[0] = 200;
         reserves[1] = 300;
@@ -99,21 +99,21 @@ contract TestGammaPool is IGammaPool, ERC20 {
         assets = 17;
     }
 
-    function depositReserves(address to, uint256[] calldata amountsDesired, uint256[] calldata amountsMin, bytes calldata data) external virtual override returns(uint256[] memory reserves, uint256 shares) {
+    function depositReserves(address, uint256[] calldata, uint256[] calldata, bytes calldata) external virtual override returns(uint256[] memory reserves, uint256 shares) {
         reserves = new uint256[](4);
         shares = 18;
     }
 
     //Long Gamma
-    function getCFMMPrice() external virtual override view returns(uint256 price) {
-        return 1;
+    function getLatestCFMMReserves() external virtual override view returns(uint256[] memory cfmmReserves) {
+        return new uint256[](2);
     }
 
     function createLoan() external virtual override returns(uint256 tokenId) {
         tokenId = 19;
     }
 
-    function loan(uint256 tokenId) external virtual override view returns (uint256 id, address poolId,
+    function loan(uint256) external virtual override view returns (uint256 id, address poolId,
         uint128[] memory tokensHeld, uint256 initLiquidity, uint256 liquidity, uint256 lpTokens, uint256 rateIndex) {
         id = 20;
         poolId = cfmm;
@@ -124,40 +124,46 @@ contract TestGammaPool is IGammaPool, ERC20 {
         initLiquidity = 24;
     }
 
-    function borrowLiquidity(uint256 tokenId, uint256 lpTokens) external virtual override returns(uint256[] memory amounts) {
+    function borrowLiquidity(uint256, uint256) external virtual override returns(uint256[] memory amounts) {
         amounts = new uint256[](2);
     }
 
-    function repayLiquidity(uint256 tokenId, uint256 liquidity) external virtual override returns(uint256 liquidityPaid, uint256[] memory amounts) {
+    function repayLiquidity(uint256, uint256) external virtual override returns(uint256 liquidityPaid, uint256[] memory amounts) {
         liquidityPaid = 24;
         amounts = new uint256[](2);
     }
 
-    function increaseCollateral(uint256 tokenId) external virtual override returns(uint128[] memory tokensHeld) {
+    function increaseCollateral(uint256) external virtual override returns(uint128[] memory tokensHeld) {
         tokensHeld = new uint128[](6);
     }
 
-    function decreaseCollateral(uint256 tokenId, uint256[] calldata amounts, address to) external virtual override returns(uint128[] memory tokensHeld) {
+    function decreaseCollateral(uint256, uint256[] calldata, address) external virtual override returns(uint128[] memory tokensHeld) {
         tokensHeld = new uint128[](7);
     }
 
-    function rebalanceCollateral(uint256 tokenId, int256[] calldata deltas) external virtual override returns(uint128[] memory tokensHeld) {
+    function rebalanceCollateral(uint256, int256[] calldata) external virtual override returns(uint128[] memory tokensHeld) {
         tokensHeld = new uint128[](2);
     }
 
-    function liquidate(uint256 tokenId, bool isRebalance, int256[] calldata deltas) external override virtual returns(uint256[] memory refund) {
+    function liquidate(uint256, int256[] calldata) external override virtual returns(uint256[] memory refund) {
         return new uint256[](2);
     }
 
-    function liquidateWithLP(uint256 tokenId) external override virtual returns(uint256[] memory refund) {
+    function liquidateWithLP(uint256) external override virtual returns(uint256[] memory refund) {
         return new uint256[](2);
     }
 
-    function batchLiquidations(uint256[] calldata tokenIds) external override virtual returns(uint256[] memory refund) {
+    function batchLiquidations(uint256[] calldata) external override virtual returns(uint256[] memory refund) {
         return new uint256[](2);
     }
 
-    function validateCFMM(address[] calldata _tokens, address _cfmm) external override view returns(address[] memory tokens, uint8[] memory decimals) {
+    function validateCFMM(address[] calldata, address) external override pure returns(address[] memory, uint8[] memory) {
         return (new address[](2), new uint8[](2));
+    }
+
+    function skim(address) external override {
+    }
+
+    function sync() external override {
     }
 }

--- a/contracts/test/TestGammaPoolFactory.sol
+++ b/contracts/test/TestGammaPoolFactory.sol
@@ -21,22 +21,22 @@ contract TestGammaPoolFactory is AbstractGammaPoolFactory {
         tester = msg.sender;
     }
 
-    function getProtocol(uint16 protocolId) external virtual override view returns(address) {
+    function getProtocol(uint16) external virtual override view returns(address) {
         return implementation;
     }
 
-    function isProtocolRestricted(uint16 protocolId) external virtual override view returns(bool) {
+    function isProtocolRestricted(uint16) external virtual override view returns(bool) {
         return false;
     }
 
-    function setIsProtocolRestricted(uint16 protocolId, bool isRestricted) external virtual override {
+    function setIsProtocolRestricted(uint16, bool) external virtual override {
     }
 
     function addProtocol(address _protocol) external virtual override {
         implementation = _protocol;
     }
 
-    function removeProtocol(uint16 protocolId) external virtual override {
+    function removeProtocol(uint16) external virtual override {
         implementation = address(0);
     }
 

--- a/contracts/test/TestPositionManager.sol
+++ b/contracts/test/TestPositionManager.sol
@@ -21,7 +21,7 @@ contract TestPositionManager is PositionManager {
         checkMinCollateral(amounts, amountsMin);
     }
 
-    function tokenURI(uint256 tokenId) public view virtual override returns (string memory) {
+    function tokenURI(uint256) public view virtual override returns (string memory) {
         return "";
     }
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
-    "@gammaswap/v1-core": "^0.2.2",
+    "@gammaswap/v1-core": "^0.2.4",
     "@openzeppelin/contracts": "^4.7.0",
     "@uniswap/v2-core": "^1.0.1",
     "@uniswap/v2-periphery": "^1.1.0-beta.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gammaswap/v1-periphery",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Periphery contracts for the GammaSwapV1 protocol",
   "homepage": "https://gammaswap.com",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
-    "@gammaswap/v1-core": "^0.2.1",
+    "@gammaswap/v1-core": "^0.2.2",
     "@openzeppelin/contracts": "^4.7.0",
     "@uniswap/v2-core": "^1.0.1",
     "@uniswap/v2-periphery": "^1.1.0-beta.0"

--- a/test/PositionManager.test.ts
+++ b/test/PositionManager.test.ts
@@ -338,7 +338,6 @@ describe("PositionManager", function () {
                 protocolId: protocolId,
                 tokenId: tokenId,
                 lpTokens: 1,
-                to: owner.address,
                 minBorrowed: [0,0],
                 deadline: ethers.constants.MaxUint256
             }
@@ -357,7 +356,6 @@ describe("PositionManager", function () {
                 protocolId: protocolId,
                 tokenId: tokenId,
                 liquidity: 1,
-                to: owner.address,
                 minRepaid: [0,0],
                 deadline: ethers.constants.MaxUint256
             }
@@ -417,7 +415,6 @@ describe("PositionManager", function () {
                 tokenId: tokenId,
                 deltas: [4, 2],
                 liquidity: 1,
-                to: owner.address,
                 minCollateral: [0,0],
                 deadline: ethers.constants.MaxUint256
             }

--- a/test/PositionManager.test.ts
+++ b/test/PositionManager.test.ts
@@ -474,7 +474,9 @@ describe("PositionManager", function () {
             expect(args3.liquidity.toNumber()).to.equal(21);
             expect(args3.lpTokens.toNumber()).to.equal(22);
             expect(args3.initLiquidity.toNumber()).to.equal(24);
-            expect(args3.lastPx.toNumber()).to.equal(1);
+            expect(args3.cfmmReserves.length).to.equal(2);
+            expect(args3.cfmmReserves[0]).to.equal(0);
+            expect(args3.cfmmReserves[1]).to.equal(0);
         });
 
         it("#createLoanBorrowAndRebalance should return tokenId, tokensHeld, amounts. Has deltas", async function () {
@@ -527,7 +529,9 @@ describe("PositionManager", function () {
             expect(args4.liquidity.toNumber()).to.equal(21);
             expect(args4.lpTokens.toNumber()).to.equal(22);
             expect(args4.initLiquidity.toNumber()).to.equal(24);
-            expect(args4.lastPx.toNumber()).to.equal(1);
+            expect(args4.cfmmReserves.length).to.equal(2);
+            expect(args4.cfmmReserves[0]).to.equal(0);
+            expect(args4.cfmmReserves[1]).to.equal(0);
         });
 
         it("#borrowAndRebalance should return tokensHeld, amounts. No deltas", async function () {
@@ -570,7 +574,9 @@ describe("PositionManager", function () {
             expect(args3.liquidity.toNumber()).to.equal(21);
             expect(args3.lpTokens.toNumber()).to.equal(22);
             expect(args3.initLiquidity.toNumber()).to.equal(24);
-            expect(args3.lastPx.toNumber()).to.equal(1);
+            expect(args3.cfmmReserves.length).to.equal(2);
+            expect(args3.cfmmReserves[0]).to.equal(0);
+            expect(args3.cfmmReserves[1]).to.equal(0);
         });
 
         it("#borrowAndRebalance should return tokensHeld, amounts. No deltas, withdraws", async function () {
@@ -619,7 +625,9 @@ describe("PositionManager", function () {
             expect(args4.liquidity.toNumber()).to.equal(21);
             expect(args4.lpTokens.toNumber()).to.equal(22);
             expect(args4.initLiquidity.toNumber()).to.equal(24);
-            expect(args4.lastPx.toNumber()).to.equal(1);
+            expect(args4.cfmmReserves.length).to.equal(2);
+            expect(args4.cfmmReserves[0]).to.equal(0);
+            expect(args4.cfmmReserves[1]).to.equal(0);
         });
 
         it("#borrowAndRebalance should return tokensHeld, amounts. Has deltas", async function () {
@@ -668,7 +676,9 @@ describe("PositionManager", function () {
             expect(args4.liquidity.toNumber()).to.equal(21);
             expect(args4.lpTokens.toNumber()).to.equal(22);
             expect(args4.initLiquidity.toNumber()).to.equal(24);
-            expect(args4.lastPx.toNumber()).to.equal(1);
+            expect(args4.cfmmReserves.length).to.equal(2);
+            expect(args4.cfmmReserves[0]).to.equal(0);
+            expect(args4.cfmmReserves[1]).to.equal(0);
         });
 
         it("#rebalanceRepayAndWithdraw should return tokensHeld, liquidityPaid, amounts. No deltas, No Withdraw", async function () {
@@ -712,7 +722,9 @@ describe("PositionManager", function () {
             expect(args3.liquidity.toNumber()).to.equal(21);
             expect(args3.lpTokens.toNumber()).to.equal(22);
             expect(args3.initLiquidity.toNumber()).to.equal(24);
-            expect(args3.lastPx.toNumber()).to.equal(1);
+            expect(args3.cfmmReserves.length).to.equal(2);
+            expect(args3.cfmmReserves[0]).to.equal(0);
+            expect(args3.cfmmReserves[1]).to.equal(0);
         });
 
         it("#rebalanceRepayAndWithdraw should return tokensHeld, liquidityPaid, amounts. No deltas, Has Withdraw", async function () {
@@ -762,7 +774,9 @@ describe("PositionManager", function () {
             expect(args4.liquidity.toNumber()).to.equal(21);
             expect(args4.lpTokens.toNumber()).to.equal(22);
             expect(args4.initLiquidity.toNumber()).to.equal(24);
-            expect(args4.lastPx.toNumber()).to.equal(1);
+            expect(args4.cfmmReserves.length).to.equal(2);
+            expect(args4.cfmmReserves[0]).to.equal(0);
+            expect(args4.cfmmReserves[1]).to.equal(0);
         });
 
         it("#rebalanceRepayAndWithdraw should return tokensHeld, liquidityPaid, amounts. Has deltas, No Withdraw", async function () {
@@ -812,7 +826,9 @@ describe("PositionManager", function () {
             expect(args4.liquidity.toNumber()).to.equal(21);
             expect(args4.lpTokens.toNumber()).to.equal(22);
             expect(args4.initLiquidity.toNumber()).to.equal(24);
-            expect(args4.lastPx.toNumber()).to.equal(1);
+            expect(args4.cfmmReserves.length).to.equal(2);
+            expect(args4.cfmmReserves[0]).to.equal(0);
+            expect(args4.cfmmReserves[1]).to.equal(0);
         });
 
         it("#rebalanceRepayAndWithdraw should return tokenId, tokensHeld, amounts. Has deltas, Has Withdraw", async function () {
@@ -868,7 +884,9 @@ describe("PositionManager", function () {
             expect(args5.liquidity.toNumber()).to.equal(21);
             expect(args5.lpTokens.toNumber()).to.equal(22);
             expect(args5.initLiquidity.toNumber()).to.equal(24);
-            expect(args5.lastPx.toNumber()).to.equal(1);
+            expect(args5.cfmmReserves.length).to.equal(2);
+            expect(args5.cfmmReserves[0]).to.equal(0);
+            expect(args5.cfmmReserves[1]).to.equal(0);
         });
 
         it("#rebalanceRepayAndWithdraw should return tokenId, tokensHeld, amounts. No Deposit, Has deltas, Has Withdraw", async function () {
@@ -917,8 +935,10 @@ describe("PositionManager", function () {
             expect(args5.tokensHeld.length).to.equal(5);
             expect(args5.liquidity.toNumber()).to.equal(21);
             expect(args5.lpTokens.toNumber()).to.equal(22);
-            expect(args5.initLiquidity.toNumber()).to.equal(24);
-            expect(args5.lastPx.toNumber()).to.equal(1);
+            expect(args5.initLiquidity.toNumber()).to.equal(24)
+            expect(args5.cfmmReserves.length).to.equal(2);
+            expect(args5.cfmmReserves[0]).to.equal(0);
+            expect(args5.cfmmReserves[1]).to.equal(0);
         });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -499,10 +499,10 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
-"@gammaswap/v1-core@^0.2.1":
-  version "0.2.1"
-  resolved "https://npm.pkg.github.com/download/@gammaswap/v1-core/0.2.1/2ab68b1ce93ee91d4d9c764ae925c44f42401211#2ab68b1ce93ee91d4d9c764ae925c44f42401211"
-  integrity sha512-PVd/fIGr4fX+caLcs70H3B6w8itWtGbbFKkET46x0nJHrp91BSNrbBHG+VmiUhrYeihlZB20V0JdHPTHXkQ+Gw==
+"@gammaswap/v1-core@^0.2.2":
+  version "0.2.2"
+  resolved "https://npm.pkg.github.com/download/@gammaswap/v1-core/0.2.2/ed68fec5e92e5d955ec376a5637b1039bd094f79#ed68fec5e92e5d955ec376a5637b1039bd094f79"
+  integrity sha512-FHnyIQuuDzs6JwHKYSit53OED/ZGLbAI1/JYZIiEvRtiOeFb9wmM/s/SRT/o2tyZ/jIGFTd/rDyUFqPVpFo8OQ==
   dependencies:
     "@openzeppelin/contracts" "^4.7.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -499,10 +499,10 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
-"@gammaswap/v1-core@^0.2.2":
-  version "0.2.2"
-  resolved "https://npm.pkg.github.com/download/@gammaswap/v1-core/0.2.2/ed68fec5e92e5d955ec376a5637b1039bd094f79#ed68fec5e92e5d955ec376a5637b1039bd094f79"
-  integrity sha512-FHnyIQuuDzs6JwHKYSit53OED/ZGLbAI1/JYZIiEvRtiOeFb9wmM/s/SRT/o2tyZ/jIGFTd/rDyUFqPVpFo8OQ==
+"@gammaswap/v1-core@^0.2.4":
+  version "0.2.4"
+  resolved "https://npm.pkg.github.com/download/@gammaswap/v1-core/0.2.4/22044da55ba381c003276063e7918763388a2023#22044da55ba381c003276063e7918763388a2023"
+  integrity sha512-d689Gj6n8AD91n8IfEXUgwC4xFjxq7B3IyibAtPZVQP750GAv0qf/r7tpbulnV8+cmg7DhH3stZRf/EReUf6DQ==
   dependencies:
     "@openzeppelin/contracts" "^4.7.0"
 


### PR DESCRIPTION
Update v1-periphery to take into account changes made to v1-strategies and v1-core. Remove some unused parameters in the structs

-Position Manager - print reserve quantities of cfmm instead of price (halborn call recommendation)
-GammaPool Events must match PositionManager (due to updates to v1-core)
-Remove struct params variables not used and other warnings (clean up)
-update unit tests and test contracts to account for changes in v1-core and v1-periphery (liquidation functions, new skim/sync functions)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203666297267865